### PR TITLE
adobe_prtk error code not in python dict

### DIFF
--- a/script_templates/postinstall
+++ b/script_templates/postinstall
@@ -19,6 +19,7 @@ PRTK_EXIT_CODES = {
     '31': "Invalid locale specified",
     '32': "Invalid SLConfig path",
     '33': "Failed to find LEID for serial",
+    '38': "Failed to make activation call because machine is offline",
 }
 
 import os

--- a/script_templates/uninstall
+++ b/script_templates/uninstall
@@ -19,6 +19,7 @@ PRTK_EXIT_CODES = {
     '31': "Invalid locale specified",
     '32': "Invalid SLConfig path",
     '33': "Failed to find LEID for serial",
+    '38': "Failed to make activation call because machine is offline",
 }
 
 import shutil


### PR DESCRIPTION
resulting in KeyError

During testing yesterday I was using a computer that was not connected to my home network, so I got a key error in python when adobe_prtk 38 error was encountered.

![screen shot 2018-08-26 at 7 55 57 pm](https://user-images.githubusercontent.com/1110967/44661337-fcd5e200-a9cf-11e8-8942-17ff1a6b11f8.png)

I'm not sure if these error codes didn't exist when your script was originally written or if they most likely don't apply etc. but there are a [few more here now](https://helpx.adobe.com/enterprise/package/help/provisioning-toolkit-enterprise.html) that may need to be added .

<img width="1440" alt="screen shot 2018-08-26 at 19 56 05" src="https://user-images.githubusercontent.com/1110967/44661371-18d98380-a9d0-11e8-8b56-1eec012f7d30.png">

Of course, in 99% of all cases a computer installing this pkg will probably be doing it form Munki and will probably be online, in which case…everything is still fine! 🙂

![screen shot 2018-08-26 at 7 57 39 pm](https://user-images.githubusercontent.com/1110967/44661418-3c043300-a9d0-11e8-9232-a9006e9b0f93.png)